### PR TITLE
Install dependencies with frozen lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   NODE_VERSION: '18'
-  PNPM_VERSION: '8'
+  PNPM_VERSION: '9'
 
 jobs:
   # Job to check for changes in specific directories
@@ -92,7 +92,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-        run: pnpm build
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         queries: security-extended,security-and-quality
@@ -40,7 +40,7 @@ jobs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:
-        version: '8'
+        version: '9'
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
@@ -52,6 +52,6 @@ jobs:
         NEXT_PUBLIC_SUPABASE_ANON_KEY: "dummy-key-for-build"
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: '8'
+          version: '9'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## توضیح کلی
این PR خطای `pnpm install --frozen-lockfile` را در CI برطرف می‌کند که ناشی از عدم تطابق نسخه pnpm و مشکلات پیکربندی workflow بود. تغییرات شامل موارد زیر است:
- به‌روزرسانی نسخه pnpm به `9` در تمامی workflowهای GitHub Actions (`ci.yml`, `codeql.yml`, `release.yml`) برای مطابقت با `pnpm-lock.yaml`.
- ارتقاء اکشن‌های CodeQL به `v3` در `codeql.yml`.
- حذف یک دستور `pnpm build` اضافی و نامناسب از مرحله lint در `ci.yml`.

## نوع تغییرات
- [x] باگ‌فیکس
- [ ] ویژگی جدید
- [x] تغییرات غیرشکست‌زا (refactor/chore)
- [ ] تغییرات شکستن‌دهنده (breaking change)

## چک‌لیست
- [ ] کد ساخته می‌شود (pnpm build)
- [ ] تایپ‌ها اوکی هستند (pnpm type-check)
- [ ] لاینت پاس می‌شود (pnpm lint)
- [ ] مستندات/README یا توضیحات لازم به‌روزرسانی شده‌اند

## موارد مرتبط
- Closes #

---
<a href="https://cursor.com/background-agent?bcId=bc-7f87896d-5ef3-4828-829d-acb70781b8bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f87896d-5ef3-4828-829d-acb70781b8bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

